### PR TITLE
Release/0.0.28

### DIFF
--- a/servicecatalog_puppet/templates/shares.template.yaml.j2
+++ b/servicecatalog_puppet/templates/shares.template.yaml.j2
@@ -119,6 +119,7 @@ Resources:
               - sns:Publish
             Effect: "Allow"
             Resource: "*"
+            Principal: "*"
             Condition:
               StringEquals:
                 aws:PrincipalOrgID: {{ ou }}{% endfor %}
@@ -141,6 +142,7 @@ Resources:
               - "s3:GetObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
+            Principal: "*"
             Condition:
               StringEquals:
                 aws:PrincipalOrgID: {{ ou }}{% endfor %}

--- a/servicecatalog_puppet/templates/shares.template.yaml.j2
+++ b/servicecatalog_puppet/templates/shares.template.yaml.j2
@@ -107,13 +107,21 @@ Resources:
       PolicyDocument:
         Id: MyTopicPolicy
         Version: '2012-10-17'
-        Statement: {% for account_id, portfolios in portfolio_use_by_account.items() %} {% if account_id != host_account_id %}
+        Statement: {% for account_id in sharing_policies.get('accounts') %} {% if account_id != host_account_id %}
           - Sid: "{{ account_id }}"
             Effect: Allow
             Principal:
               AWS: !Sub "arn:aws:iam::{{ account_id }}:root"
             Action: sns:Publish
             Resource: "*"{% endif %}{% endfor %}
+        {% for ou in sharing_policies.get('ous') %}
+          - Action:
+              - sns:Publish
+            Effect: "Allow"
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:PrincipalOrgID: {{ ou }}{% endfor %}
 
 
   BucketPolicies:
@@ -121,13 +129,21 @@ Resources:
     Properties:
       Bucket: !Sub "sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}"
       PolicyDocument:
-        Statement:{% for account_id, portfolios in portfolio_use_by_account.items() %} {% if account_id != host_account_id %}
+        Statement:{% for account_id in sharing_policies.get('accounts') %} {% if account_id != host_account_id %}
           - Action:
               - "s3:GetObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
             Principal:
               AWS: "arn:aws:iam::{{ account_id }}:root"{% endif %}{% endfor %}
+        {% for ou in sharing_policies.get('ous') %}
+          - Action:
+              - "s3:GetObject"
+            Effect: "Allow"
+            Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
+            Condition:
+              StringEquals:
+                aws:PrincipalOrgID: {{ ou }}{% endfor %}
 
 
 {% for account_id, portfolios in portfolio_use_by_account.items() %}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_puppet/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-puppet",
-    version="0.0.27",
+    version="0.0.28",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to deploy ServiceCatalog products",


### PR DESCRIPTION
*Issue #26*

*Description of changes:*
Changed shares template to use principalOrgId when users specify ou within the manifest, otherwise it will continue to use account ids.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
