### PR TITLE
Release/0.0.29

### DIFF
--- a/servicecatalog_puppet/cli.py
+++ b/servicecatalog_puppet/cli.py
@@ -337,15 +337,15 @@ def write_templates(deployment_map):
 def generate_bucket_policies_for_shares(deployment_map):
     shares = {
         'accounts': [],
-        'ous': [],
+        'organizations': [],
     }
     for account_id, deployment in deployment_map.items():
         if deployment.get('expanded_from') is None:
             if account_id not in shares['accounts']:
                 shares['accounts'].append(account_id)
         else:
-            if deployment.get('expanded_from') not in shares['ous']:
-                shares['ous'].append(deployment.get('expanded_from'))
+            if deployment.get('organization') not in shares['organizations']:
+                shares['organizations'].append(deployment.get('organization'))
     return shares
 
 
@@ -883,10 +883,6 @@ def list_launches(f):
     click.echo(AsciiTable(table).table)
 
 
-
-
-
-
 def expand_path(account, client):
     ou = client.convert_path_to_ou(account.get('ou'))
     account['ou'] = ou
@@ -906,6 +902,7 @@ def expand_ou(original_account, client):
         new_account['email'] = response.get('Account').get('Email')
         new_account['account_id'] = new_account_id
         new_account['expanded_from'] = original_account.get('ou')
+        new_account['organization'] = response.get('Account').get('Arn').split(":")[5].split("/")[1]
         expanded.append(new_account)
     return expanded
 

--- a/servicecatalog_puppet/templates/shares.template.yaml.j2
+++ b/servicecatalog_puppet/templates/shares.template.yaml.j2
@@ -114,7 +114,7 @@ Resources:
               AWS: !Sub "arn:aws:iam::{{ account_id }}:root"
             Action: sns:Publish
             Resource: "*"{% endif %}{% endfor %}
-        {% for ou in sharing_policies.get('ous') %}
+        {% for organization in sharing_policies.get('organizations') %}
           - Action:
               - sns:Publish
             Effect: "Allow"
@@ -122,7 +122,7 @@ Resources:
             Principal: "*"
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: {{ ou }}{% endfor %}
+                aws:PrincipalOrgID: {{ organization }}{% endfor %}
 
 
   BucketPolicies:
@@ -137,7 +137,7 @@ Resources:
             Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
             Principal:
               AWS: "arn:aws:iam::{{ account_id }}:root"{% endif %}{% endfor %}
-        {% for ou in sharing_policies.get('ous') %}
+        {% for organization in sharing_policies.get('organizations') %}
           - Action:
               - "s3:GetObject"
             Effect: "Allow"
@@ -145,7 +145,7 @@ Resources:
             Principal: "*"
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: {{ ou }}{% endfor %}
+                aws:PrincipalOrgID: {{ organization }}{% endfor %}
 
 
 {% for account_id, portfolios in portfolio_use_by_account.items() %}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_puppet/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-puppet",
-    version="0.0.28",
+    version="0.0.29",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to deploy ServiceCatalog products",


### PR DESCRIPTION
*Issue #26*

*Description of changes:*
When you are using orgs in manifest file the shares template now uses organization id with principal org id instead of explicit account ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
