### PR TITLE
Issue/62

### DIFF
--- a/servicecatalog_puppet/aws.py
+++ b/servicecatalog_puppet/aws.py
@@ -63,10 +63,22 @@ def get_stack_output_for(cloudformation, stack_name):
     return cloudformation.describe_stacks(StackName=stack_name).get('Stacks')[0]
 
 
+def get_default_parameters_for_stack(cloudformation, stack_name):
+    logger.info(f"Getting default parameters for for {stack_name}")
+    existing_stack_params_dict = {}
+    summary_response = cloudformation.get_template_summary(
+        StackName=stack_name,
+    )
+    for parameter in summary_response.get('Parameters'):
+        existing_stack_params_dict[parameter.get('ParameterKey')] = parameter.get('DefaultValue')
+    return existing_stack_params_dict
+
+
 def get_parameters_for_stack(cloudformation, stack_name):
+    existing_stack_params_dict = get_default_parameters_for_stack(cloudformation, stack_name)
+
     logger.info(f"Getting parameters for for {stack_name}")
     stack = get_stack_output_for(cloudformation, stack_name)
-    existing_stack_params_dict = {}
     for stack_param in stack.get('Parameters', []):
         existing_stack_params_dict[stack_param.get('ParameterKey')] = stack_param.get('ParameterValue')
     return existing_stack_params_dict

--- a/servicecatalog_puppet/cli.py
+++ b/servicecatalog_puppet/cli.py
@@ -148,7 +148,7 @@ def get_parameters_for_launch(required_parameters, deployment_map, manifest, lau
         launch_ssm_param = launch_params.get(required_parameter_name, {}).get('ssm')
         launch_regular_param = launch_params.get(required_parameter_name, {}).get('default')
 
-        manifest_params = manifest.get('parameters')
+        manifest_params = manifest.get('parameters', {})
         manifest_ssm_param = manifest_params.get(required_parameter_name, {}).get('ssm')
         manifest_regular_param = manifest_params.get(required_parameter_name, {}).get('default')
 


### PR DESCRIPTION
*Issue #62 and #63*

*Description of changes:*
Parameter checking to see if we should update a provisioned product did not consider the default values of parameters in the CloudFormation template.  These default values are used when no others are specified.  This was causing Service Catalog to run a product plan that thought there were changes but CloudFormation was aware there were no changes.  The CloudFormation changeset was invalid and caused ServiceCatalog to taint the product.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
