### PR TITLE
Feature/ensure product owner

### DIFF
--- a/servicecatalog_puppet/aws.py
+++ b/servicecatalog_puppet/aws.py
@@ -122,11 +122,12 @@ def provision_product(
             logger.info(f"{uid} :: Checking product: {provisioned_product_search_result}")
             if provisioned_product_search_result.get('Name') == launch_name:
                 logger.info(f"{uid} :: found provisioned product for this launch / account / region, going to update")
-                service_catalog.update_provisioned_product_properties(
+                result = service_catalog.update_provisioned_product_properties(
                     ProvisionedProductId=provisioned_product_search_result.get('Id'),
                     ProvisionedProductProperties={'OWNER': f"arn:aws:iam::{account_id}:role/servicecatalog-puppet/PuppetRole"}
-                )
-                time.sleep(20)
+                ).get('Status')
+                if result != "SUCCEEDED":
+                    raise Exception("Could not update OWNER")
                 logger.info(f"{uid} :: finished the update")
     logger.info(f"[{launch_name}] {account_id}:{region} :: Checking for an existing plan")
     if puppet_account_id == account_id:

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -98,6 +98,8 @@ class ProvisionProductTask(PuppetTask):
 
     ssm_param_outputs = luigi.ListParameter(default=[])
 
+    ensure_owner = luigi.Parameter(default="false", significant=False)
+
     try_count = 1
 
     def requires(self):
@@ -234,6 +236,7 @@ class ProvisionProductTask(PuppetTask):
                         aws.get_path_for_product(service_catalog, self.product_id),
                         all_params,
                         self.version,
+                        self.ensure_owner=="true",
                     )
 
                 with betterboto_client.CrossAccountClientContextManager(

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -46,9 +46,14 @@ class PuppetTask(luigi.Task):
     @property
     def resources(self):
         resources_for_this_task = {}
-
+        resource_parts = []
         if hasattr(self, 'region'):
-            resources_for_this_task[self.region] = 1
+            resource_parts.append(self.region)
+        if hasattr(self, 'account_id'):
+            resource_parts.append(self.account_id)
+
+        if len(resource_parts) > 0:
+            resources_for_this_task["_".join(resource_parts)] = 1
 
         return resources_for_this_task
 

--- a/servicecatalog_puppet/requirements.txt
+++ b/servicecatalog_puppet/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.10.1
 click==7.0
 boto3==1.9.102
 pykwalify==1.7.0
-better-boto==0.11.0
+better-boto==0.12.0
 terminaltables==3.1.0
 colorclass==2.2.0
 luigi==2.8.6

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_puppet/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-puppet",
-    version="0.12.0",
+    version="0.13.0",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to deploy ServiceCatalog products",


### PR DESCRIPTION
*Issue #105*

*Description of changes:*
AWS Service Catalog records the owner of a product as the unique id of the puppet role. Recreation of the PuppetRole causes a new unique id to be created and the owner of the product is no longer active.  This feature exposes a mechanism to set the owner of a product before it is updated so that it can be updated in those instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
