### PR TITLE
Issues/124

### DIFF
--- a/docs/source/puppet/sharing_a_portfolio.rst
+++ b/docs/source/puppet/sharing_a_portfolio.rst
@@ -24,14 +24,14 @@ In addition to this, you can specify associations for the created portfolio and 
 How can I set it up?
 --------------------
 
-The following is an example of how to add the portfolio ``demo-central-it-team-portfolio`` to all spokes tagged
+The following is an example of how to add the portfolio ``example-simple-central-it-team-portfolio`` to all spokes tagged
 ``scope:spoke``:
 
 .. code-block:: yaml
 
     spoke-local-portfolios:
       account-vending-for-spokes:
-        portfolio: demo-central-it-team-portfolio
+        portfolio: example-simple-central-it-team-portfolio
         depends_on:
           - account-iam-for-spokes
         associations:
@@ -95,7 +95,7 @@ Using a list:
 
     spoke-local-portfolios:
       account-vending-for-spokes:
-        portfolio: demo-central-it-team-portfolio
+        portfolio: example-simple-central-it-team-portfolio
         depends_on:
           - account-iam-for-spokes
         associations:
@@ -119,7 +119,7 @@ Using a regular expression:
 
     spoke-local-portfolios:
       account-vending-for-spokes:
-        portfolio: demo-central-it-team-portfolio
+        portfolio: example-simple-central-it-team-portfolio
         depends_on:
           - account-iam-for-spokes
         associations:

--- a/servicecatalog_puppet/cli_command_helpers.py
+++ b/servicecatalog_puppet/cli_command_helpers.py
@@ -456,7 +456,7 @@ def deploy_spoke_local_portfolios(manifest, launch_tasks):
         for launch_name, launch_details in deployments_for_account.get(section).items():
             for region_name in launch_details.get('regions'):
 
-                depends_on = launch_details.get('depends_on')
+                depends_on = launch_details.get('depends_on', [])
                 dependencies = []
                 for dependency in depends_on:
                     for task_uid, task in launch_tasks.items():

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -921,8 +921,18 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                             PortfolioId=portfolio_id,
                         )
 
+                        spoke_provisioning_artifact_details = spoke_service_catalog.list_provisioning_artifacts(
+                            ProductId=target_product_id
+                        ).get('ProvisioningArtifactDetails', [])
                         for version_name, version_details in product_versions_that_should_be_copied.items():
                             logging.info(f"{version_name} is active: {version_details.get('Active')}")
+                            for spoke_provisioning_artifact_detail in spoke_provisioning_artifact_details:
+                                if spoke_provisioning_artifact_detail.get('Name') == version_name:
+                                    spoke_service_catalog.update_provisioning_artifact(
+                                        ProductId=target_product_id,
+                                        ProvisioningArtifactId=spoke_provisioning_artifact_detail.get('Id'),
+                                        Active=version_details.get('Active'),
+                                    )
 
                         # associate_product_with_portfolio is not a synchronous request
                         logger.info(f"[{self.portfolio}] {self.account_id}:{self.region} :: waiting for adding of "

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -873,16 +873,17 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                         for spoke_product_view_details in p.get('ProductViewDetails'):
                             spoke_product_view = spoke_product_view_details.get('ProductViewSummary')
                             if spoke_product_view.get('Name') == hub_product_name:
-                                copy_args['TargetProductId'] = spoke_product_view.get('ProductId')
+                                spoke_product_id = spoke_product_view.get('ProductId')
+                                copy_args['TargetProductId'] = spoke_product_id
                                 spoke_provisioning_artifact_details = spoke_service_catalog.list_provisioning_artifacts(
-                                    ProductId=spoke_product_view.get('ProductId')
+                                    ProductId=spoke_product_id
                                 ).get('ProvisioningArtifactDetails')
                                 for provisioning_artifact_detail in spoke_provisioning_artifact_details:
                                     id_to_delete = f"{provisioning_artifact_detail.get('Name')}"
                                     if product_versions_that_should_be_copied.get(id_to_delete, None) is not None:
                                         logger.info(f"[{self.portfolio}] {self.account_id}:{self.region} "
                                                     f"{hub_product_name} :: Going to skip "
-                                                    f"{spoke_product_view.get('ProductId')} "
+                                                    f"{spoke_product_id} "
                                                     f"{provisioning_artifact_detail.get('Name')}"
                                                     )
                                         del product_versions_that_should_be_copied[id_to_delete]
@@ -946,7 +947,7 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                         product_name_to_id_dict[hub_product_name] = target_product_id
 
                     spoke_provisioning_artifact_details = spoke_service_catalog.list_provisioning_artifacts(
-                        ProductId=target_product_id
+                        ProductId=spoke_product_id
                     ).get('ProvisioningArtifactDetails', [])
                     for version_name, version_details in product_versions_that_should_be_updated.items():
                         logging.info(f"{version_name} is active: {version_details.get('Active')} in hub")

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -946,8 +946,9 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
 
                         product_name_to_id_dict[hub_product_name] = target_product_id
 
+                    product_id_in_spoke = spoke_product_id or target_product_id
                     spoke_provisioning_artifact_details = spoke_service_catalog.list_provisioning_artifacts(
-                        ProductId=spoke_product_id
+                        ProductId=product_id_in_spoke
                     ).get('ProvisioningArtifactDetails', [])
                     for version_name, version_details in product_versions_that_should_be_updated.items():
                         logging.info(f"{version_name} is active: {version_details.get('Active')} in hub")
@@ -958,7 +959,7 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                                     f"in the spoke to {version_details.get('Active')}"
                                 )
                                 spoke_service_catalog.update_provisioning_artifact(
-                                    ProductId=spoke_product_id,
+                                    ProductId=product_id_in_spoke,
                                     ProvisioningArtifactId=spoke_provisioning_artifact_detail.get('Id'),
                                     Active=version_details.get('Active'),
                                 )

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -824,6 +824,8 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
         ) as service_catalog:
             response = service_catalog.search_products_as_admin_single_page(PortfolioId=self.hub_portfolio_id)
             for product_view_detail in response.get('ProductViewDetails', []):
+                spoke_product_id = False
+                target_product_id = False
                 product_view_summary = product_view_detail.get('ProductViewSummary')
                 hub_product_name = product_view_summary.get('Name')
                 hub_product_id = product_view_summary.get('ProductId')

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -833,10 +833,10 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                     ProductId=hub_product_id
                 ).get('ProvisioningArtifactDetails', [])
                 for hub_provisioning_artifact_detail in hub_provisioning_artifact_details:
-                    if hub_provisioning_artifact_detail.get('Active') and hub_provisioning_artifact_detail.get(
-                            'Type') == 'CLOUD_FORMATION_TEMPLATE':
+                    if hub_provisioning_artifact_detail.get('Type') == 'CLOUD_FORMATION_TEMPLATE':
                         product_versions_that_should_be_copied[
-                            f"{hub_provisioning_artifact_detail.get('Name')}"] = hub_provisioning_artifact_detail
+                            f"{hub_provisioning_artifact_detail.get('Name')}"
+                        ] = hub_provisioning_artifact_detail
 
                 logger.info(f"[{self.portfolio}] {self.account_id}:{self.region} :: Copying {hub_product_name}")
                 hub_product_arn = product_view_detail.get('ProductARN')
@@ -920,6 +920,9 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                             ProductId=target_product_id,
                             PortfolioId=portfolio_id,
                         )
+
+                        for version_name, version_details in product_versions_that_should_be_copied.items():
+                            logging.info(f"{version_name} is active: {version_details.get('Active')}")
 
                         # associate_product_with_portfolio is not a synchronous request
                         logger.info(f"[{self.portfolio}] {self.account_id}:{self.region} :: waiting for adding of "

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -925,9 +925,10 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                             ProductId=target_product_id
                         ).get('ProvisioningArtifactDetails', [])
                         for version_name, version_details in product_versions_that_should_be_copied.items():
-                            logging.info(f"{version_name} is active: {version_details.get('Active')}")
+                            logging.info(f"{version_name} is active: {version_details.get('Active')} in hub")
                             for spoke_provisioning_artifact_detail in spoke_provisioning_artifact_details:
                                 if spoke_provisioning_artifact_detail.get('Name') == version_name:
+                                    logging.info(f"Updating {version_name}/{spoke_provisioning_artifact_detail.get('Id')} in the spoke")
                                     spoke_service_catalog.update_provisioning_artifact(
                                         ProductId=target_product_id,
                                         ProvisioningArtifactId=spoke_provisioning_artifact_detail.get('Id'),

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -953,9 +953,12 @@ class ImportIntoSpokeLocalPortfolioTask(PuppetTask):
                         logging.info(f"{version_name} is active: {version_details.get('Active')} in hub")
                         for spoke_provisioning_artifact_detail in spoke_provisioning_artifact_details:
                             if spoke_provisioning_artifact_detail.get('Name') == version_name:
-                                logging.info(f"Updating {version_name}/{spoke_provisioning_artifact_detail.get('Id')} in the spoke")
+                                logging.info(
+                                    f"Updating active of {version_name}/{spoke_provisioning_artifact_detail.get('Id')} "
+                                    f"in the spoke to {version_details.get('Active')}"
+                                )
                                 spoke_service_catalog.update_provisioning_artifact(
-                                    ProductId=target_product_id,
+                                    ProductId=spoke_product_id,
                                     ProvisioningArtifactId=spoke_provisioning_artifact_detail.get('Id'),
                                     Active=version_details.get('Active'),
                                 )

--- a/servicecatalog_puppet/manifests/manifest-simple.yaml
+++ b/servicecatalog_puppet/manifests/manifest-simple.yaml
@@ -16,7 +16,7 @@ accounts:
 
 launches:
   account-iam-for-prod:
-    portfolio: demo-central-it-team-portfolio
+    portfolio: example-simple-central-it-team-portfolio
     product: account-iam
     version: v1
     parameters:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_puppet/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-puppet",
-    version="0.25.0",
+    version="0.26.0",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to deploy ServiceCatalog products",


### PR DESCRIPTION
*Issue #124*

*Description of changes:*
- Missing depends_on no longer breaks spoke-local-portfolios
- Made puppet and factory seed command portfolio names the same to help build demos more easily
- Improved docs
- Disabling a product in the hub portfolio now cascades to the spokes when sharing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
