### PR TITLE
Feature/policies in luigi

### DIFF
--- a/servicecatalog_puppet/cli_command_helpers.py
+++ b/servicecatalog_puppet/cli_command_helpers.py
@@ -25,6 +25,8 @@ import os
 from threading import Thread
 
 import yaml
+
+import boto3
 from betterboto import client as betterboto_client
 from jinja2 import Environment, FileSystemLoader
 
@@ -846,6 +848,7 @@ def run_tasks_for_generate_shares(tasks_to_run):
     sharing_policies = {
         'accounts': [],
         'organizations': [],
+        'organization_id': ''
     }
     version = get_puppet_version()
 
@@ -865,6 +868,12 @@ def run_tasks_for_generate_shares(tasks_to_run):
                     ou = ou_file.split(".")[0]
                     sharing_policies['organizations'].append(ou)
     logger.info(f"Finished updating policies")
+
+    logger.info(f"Getting organization id")
+    organizations_client = boto3.client('organizations')
+    organization_id = organizations_client.describe_organization().get('Organization').get('Id')
+    sharing_policies['organization_id'] = organization_id
+    logger.info(f"Finished getting organization id")
 
     template = env.get_template('policies.template.yaml.j2').render(
         sharing_policies=sharing_policies,

--- a/servicecatalog_puppet/cli_commands.py
+++ b/servicecatalog_puppet/cli_commands.py
@@ -58,7 +58,7 @@ def generate_shares(f):
                 account_id=account_id,
                 puppet_account_id=puppet_account_id,
                 deployment_map_for_account=deployment_map_for_account,
-                'launches',
+                sharing_type='launches',
             )
         )
 
@@ -69,7 +69,7 @@ def generate_shares(f):
                 account_id=account_id,
                 puppet_account_id=puppet_account_id,
                 deployment_map_for_account=import_map_for_account,
-                'spoke-local-portfolios',
+                sharing_type='spoke-local-portfolios',
             )
         )
 

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -1614,9 +1614,9 @@ class CreateShareForAccountLaunch(PuppetTask):
                     target_regions = tag_details.get('regions', 'default_region')
             assert target_regions is not None, "Could not find the tag for this provisioning"
             if target_regions == "default_region":
-                target_regions = [self.mutable_deployment_map.get('default_region')]
+                target_regions = [mutable_deployment_map.get('default_region')]
             elif target_regions in ["regions_enabled", "enabled_regions"]:
-                target_regions = self.mutable_deployment_map.get('regions_enabled')
+                target_regions = mutable_deployment_map.get('regions_enabled')
         elif match == "account_match":
             target_regions = None
             for accounts_details in self.launch_details.get('deploy_to').get('accounts'):
@@ -1624,9 +1624,9 @@ class CreateShareForAccountLaunch(PuppetTask):
                     target_regions = accounts_details.get('regions', 'default_region')
             assert target_regions is not None, "Could not find the account_id for this provisioning"
             if target_regions == "default_region":
-                target_regions = [self.mutable_deployment_map.get('default_region')]
+                target_regions = [mutable_deployment_map.get('default_region')]
             elif target_regions in ["regions_enabled", "enabled_regions"]:
-                target_regions = self.mutable_deployment_map.get('regions_enabled')
+                target_regions = mutable_deployment_map.get('regions_enabled')
 
         else:
             raise Exception(f"{self.uid}: Unknown match: {match}")
@@ -1635,7 +1635,7 @@ class CreateShareForAccountLaunch(PuppetTask):
             deps[f"{self.account_id}-{self.launch_name}-{region}"] = CreateShareForAccountLaunchRegion(
                 self.account_id,
                 self.puppet_account_id,
-                self.mutable_deployment_map,
+                self.deployment_map_for_account,
                 self.launch_name,
                 self.launch_details,
                 region,

--- a/servicecatalog_puppet/luigi_tasks_and_targets.py
+++ b/servicecatalog_puppet/luigi_tasks_and_targets.py
@@ -1603,6 +1603,7 @@ class CreateShareForAccountLaunch(PuppetTask):
 
     def requires(self):
         deps = {}
+        mutable_deployment_map = dict(self.deployment_map_for_account)
         match = self.launch_details.get('match')
         logging.info(f"{self.uid}: Starting match was {match}")
         if match == "tag_match":
@@ -1613,9 +1614,9 @@ class CreateShareForAccountLaunch(PuppetTask):
                     target_regions = tag_details.get('regions', 'default_region')
             assert target_regions is not None, "Could not find the tag for this provisioning"
             if target_regions == "default_region":
-                target_regions = [self.deployment_map_for_account.get('default_region')]
+                target_regions = [self.mutable_deployment_map.get('default_region')]
             elif target_regions in ["regions_enabled", "enabled_regions"]:
-                target_regions = self.deployment_map_for_account.get('regions_enabled')
+                target_regions = self.mutable_deployment_map.get('regions_enabled')
         elif match == "account_match":
             target_regions = None
             for accounts_details in self.launch_details.get('deploy_to').get('accounts'):
@@ -1623,9 +1624,9 @@ class CreateShareForAccountLaunch(PuppetTask):
                     target_regions = accounts_details.get('regions', 'default_region')
             assert target_regions is not None, "Could not find the account_id for this provisioning"
             if target_regions == "default_region":
-                target_regions = [self.deployment_map_for_account.get('default_region')]
+                target_regions = [self.mutable_deployment_map.get('default_region')]
             elif target_regions in ["regions_enabled", "enabled_regions"]:
-                target_regions = self.deployment_map_for_account.get('regions_enabled')
+                target_regions = self.mutable_deployment_map.get('regions_enabled')
 
         else:
             raise Exception(f"{self.uid}: Unknown match: {match}")
@@ -1634,7 +1635,7 @@ class CreateShareForAccountLaunch(PuppetTask):
             deps[f"{self.account_id}-{self.launch_name}-{region}"] = CreateShareForAccountLaunchRegion(
                 self.account_id,
                 self.puppet_account_id,
-                self.deployment_map_for_account,
+                self.mutable_deployment_map,
                 self.launch_name,
                 self.launch_details,
                 region,

--- a/servicecatalog_puppet/templates/policies.template.yaml.j2
+++ b/servicecatalog_puppet/templates/policies.template.yaml.j2
@@ -25,21 +25,21 @@ Resources:
         Id: MyTopicPolicy
         Version: '2012-10-17'
         Statement: {% for account_id in sharing_policies.get('accounts') %}
-          - Sid: "{{ account_id }}"
+          - Sid: "ShareFor{{ account_id }}"
             Effect: Allow
             Principal:
               AWS: !Sub "arn:aws:iam::{{ account_id }}:root"
             Action: sns:Publish
             Resource: "*"{% endfor %}
-        {% for organization in sharing_policies.get('organizations') %}
-          - Action:
+          - Sid: OrganizationalShareFor{{ sharing_policies.get('organization_id') }}
+            Action:
               - sns:Publish
             Effect: "Allow"
             Resource: "*"
             Principal: "*"
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: {{ organization }}{% endfor %}
+                aws:PrincipalOrgID: {{ sharing_policies.get('organization_id') }}
   {% endif %}
 
   {% if sharing_policies.get('accounts')|length > 0 or sharing_policies.get('organizations')|length > 0 %}
@@ -49,19 +49,20 @@ Resources:
       Bucket: !Sub "sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}"
       PolicyDocument:
         Statement:{% for account_id in sharing_policies.get('accounts') %}
-          - Action:
+          - Sid: ShareFor{{ account_id }}
+            Action:
               - "s3:GetObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
             Principal:
               AWS: "arn:aws:iam::{{ account_id }}:root"{% endfor %}
-        {% for organization in sharing_policies.get('organizations') %}
-          - Action:
+          - Sid: OrganizationalShareFor{{ sharing_policies.get('organization_id') }}
+            Action:
               - "s3:GetObject"
             Effect: "Allow"
             Resource: !Sub "arn:aws:s3:::sc-factory-artifacts-${AWS::AccountId}-${AWS::Region}/*"
             Principal: "*"
             Condition:
               StringEquals:
-                aws:PrincipalOrgID: {{ organization }}{% endfor %}
+                aws:PrincipalOrgID: {{ sharing_policies.get('organization_id') }}
   {% endif %}


### PR DESCRIPTION
# Region endpoint error
In the `CreateShareForAccountLaunch` Luigi task, when the match type is `account_match` we see
weird behavior where the individual characters of some region names were interpreted as the region
itself. Upon further investigation, the `deployment_map_for_account` variable is of type `FrozenOrderedDict`
which is an immutable data type, and thus converted all lists in the dict to tuples. In the REPL
we can replicate the behavior of Puppet.

```python
>>> region = ('us-east-1')
>>> for item in region:
...     print(item)
...
u
s
-
e
a
s
t
-
1
```

This has been fixed by casting the immutable Luigi parameter to a mutable dictionary and referencing that instead.

# Policy generation / policies.template.yaml.j2
The existing policies in the stack **must** have unique sids, this issue was solved by adding sids
which corrospond to either the account or organization id.

This template also makes use of `aws:PrincipalOrgID` for topic policy conditions. Unfortunately the
parameter passed in to the template in the `organizations` value is actually the OU ID, which as far
as I'm aware, will not work in place of the org id.

# Surperfluous pipeline stage
The `SetupShares` pipeline stage exists in the Puppet pipeline still, as there are no longer any
cfn artefacts it can deploy, it fails. This was solved by manually removing this pipeline stage. **NOTE:** This is not rectified as part of this PR
