### PR TITLE
adding tag to service catalog products

### DIFF
--- a/servicecatalog_puppet/aws.py
+++ b/servicecatalog_puppet/aws.py
@@ -145,6 +145,10 @@ def provision_product_with_plan(
         ProvisioningParameters=provisioning_parameters,
         Tags=[
             {
+                'Key': 'ServiceCatalogPuppet:Actor',
+                'Value': "Generated",
+            },
+            {
                 'Key': 'launch_name',
                 'Value': launch_name,
             },
@@ -252,6 +256,10 @@ def provision_product(
         ProvisionedProductName=launch_name,
         ProvisioningParameters=provisioning_parameters,
         Tags=[
+            {
+                'Key': 'ServiceCatalogPuppet:Actor',
+                'Value': "Generated",
+            },
             {
                 'Key': 'launch_name',
                 'Value': launch_name,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws-service-catalog-puppet",
-    version="0.59.0",
+    version="0.60.0",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to deploy ServiceCatalog products",


### PR DESCRIPTION
*Issue #225*

*Description of changes:*
Service Catalog Products provisioned using the framework have the following tag by default: Key=ServiceCatalogPuppet:Actor,Value=Generated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
