### PR TITLE
Adding path option to list_resources cli command so that specific fil…

### DIFF
--- a/servicecatalog_puppet/cli.py
+++ b/servicecatalog_puppet/cli.py
@@ -186,8 +186,10 @@ def run(what, tail):
 
 
 @cli.command()
-def list_resources():
-    core.list_resources()
+@click.option('--path','-p', default=False, multiple=True)
+
+def list_resources(path):
+    core.list_resources(path)
 
 
 @cli.command()

--- a/servicecatalog_puppet/core.py
+++ b/servicecatalog_puppet/core.py
@@ -722,46 +722,53 @@ def run(what, tail):
     )
 
 
-def list_resources():
+def list_resources(path):
     click.echo("# Framework resources")
 
     click.echo("## SSM Parameters used")
     click.echo(f"- {constants.CONFIG_PARAM_NAME}")
     click.echo(f"- {constants.CONFIG_PARAM_NAME_ORG_IAM_ROLE_ARN}")
 
-    for file in Path(__file__).parent.resolve().glob("*.template.yaml"):
-        if 'empty.template.yaml' == file.name:
-            continue
-        template_contents = Template(open(file, 'r').read()).render()
-        template = cfn_tools.load_yaml(template_contents)
-        click.echo(f"## Resources for stack: {file.name.split('.')[0]}")
-        table_data = [
-            ['Logical Name', 'Resource Type', 'Name', ],
-        ]
-        table = terminaltables.AsciiTable(table_data)
-        for logical_name, resource in template.get('Resources').items():
-            resource_type = resource.get('Type')
-            name = '-'
-            type_to_name = {
-                'AWS::IAM::Role': 'RoleName',
-                'AWS::SSM::Parameter': 'Name',
-                'AWS::S3::Bucket': 'BucketName',
-                'AWS::CodePipeline::Pipeline': 'Name',
-                'AWS::CodeBuild::Project': 'Name',
-                'AWS::CodeCommit::Repository': 'RepositoryName',
-                'AWS::SNS::Topic': 'TopicName',
-                'AWS::SQS::Queue': 'QueueName',
-            }
+    puppet_file = Path(__file__).parent.resolve().glob("*.template.yaml")
+    for file in puppet_file:
+        list_resources_table(file)
 
-            if type_to_name.get(resource_type) is not None:
-                name = resource.get('Properties', {}).get(type_to_name.get(resource_type), 'Not Specified')
-                if not isinstance(name, str):
-                    name = cfn_tools.dump_yaml(name)
+    if path:
+        for p in path:
+            product_file = Path().parent.resolve().glob(p)
+            for f in product_file:
+                list_resources_table(f)
 
-            table_data.append([logical_name, resource_type, name])
+def list_resources_table(file):
+    template_contents = Template(open(file, 'r').read()).render()
+    template = cfn_tools.load_yaml(template_contents)
+    click.echo(f"## Resources for stack: {file.name.split('.')[0]}")
+    table_data = [
+        ['Logical Name', 'Resource Type', 'Name', ],
+    ]
+    table = terminaltables.AsciiTable(table_data)
+    for logical_name, resource in template.get('Resources').items():
+        resource_type = resource.get('Type')
+        name = '-'
+        type_to_name = {
+            'AWS::IAM::Role': 'RoleName',
+            'AWS::SSM::Parameter': 'Name',
+            'AWS::S3::Bucket': 'BucketName',
+            'AWS::CodePipeline::Pipeline': 'Name',
+            'AWS::CodeBuild::Project': 'Name',
+            'AWS::CodeCommit::Repository': 'RepositoryName',
+            'AWS::SNS::Topic': 'TopicName',
+            'AWS::SQS::Queue': 'QueueName',
+        }
 
-        click.echo(table.table)
-    click.echo(f"n.b. AWS::StackName evaluates to {constants.BOOTSTRAP_STACK_NAME}")
+        if type_to_name.get(resource_type) is not None:
+            name = resource.get('Properties', {}).get(type_to_name.get(resource_type), 'Not Specified')
+            if not isinstance(name, str):
+                name = cfn_tools.dump_yaml(name)
+
+        table_data.append([logical_name, resource_type, name])
+
+    click.echo(table.table)
 
 
 def import_product_set(f, name, portfolio_name):


### PR DESCRIPTION
Adding path option to list_resources cli command so that specific files can be targeted.

Usage:

`
$ servicecatalog-puppet list-resources --help    
Usage: servicecatalog-puppet list-resources [OPTIONS]

Options:
  -p, --path TEXT
  --help           Show this message and exit.
`

If path is not specified servicecatalog-puppet will return puppet template resources only. 
If path is specified then these resources will be appended to the output along with puppet template resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
