### PR TITLE
Provide skip_shares argument to be passed to the deploy command & Re-Introducing generate-shares to be optionally called if required.

### DIFF
--- a/servicecatalog_puppet/cli.py
+++ b/servicecatalog_puppet/cli.py
@@ -20,8 +20,9 @@ def cli(info, info_line_numbers):
 @click.option('--single-account', default=None)
 @click.option('--num-workers', default=10)
 @click.option('--execution-mode', default='hub')
-def deploy(f, single_account, num_workers, execution_mode):
-    core.deploy(f, single_account, num_workers, execution_mode=execution_mode)
+@click.option('--skip-shares', default=None)
+def deploy(f, single_account, num_workers, execution_mode, skip_shares):
+    core.deploy(f, single_account, num_workers, execution_mode=execution_mode, skip_shares=skip_shares)
 
 
 @cli.command()

--- a/servicecatalog_puppet/core.py
+++ b/servicecatalog_puppet/core.py
@@ -75,7 +75,7 @@ def reset_provisioned_product_owner(f):
     runner.run_tasks(tasks_to_run, 10)
 
 
-def generate_tasks(f, single_account=None, is_dry_run=False, execution_mode='hub'):
+def generate_tasks(f, single_account=None, is_dry_run=False, execution_mode='hub', skip_shares=False):
     logger.error(f"core.generate_tasks execution_mode is {execution_mode}")
     puppet_account_id = config.get_puppet_account_id()
 
@@ -106,9 +106,9 @@ def generate_tasks(f, single_account=None, is_dry_run=False, execution_mode='hub
     ]
 
 
-def deploy(f, single_account, num_workers=10, is_dry_run=False, is_list_launches=False, execution_mode='hub'):
+def deploy(f, single_account, num_workers=10, is_dry_run=False, is_list_launches=False, execution_mode='hub', skip_shares=False):
     logger.error(f"core.deploy execution_mode is {execution_mode}")
-    tasks_to_run = generate_tasks(f, single_account, is_dry_run, execution_mode)
+    tasks_to_run = generate_tasks(f, single_account, is_dry_run, execution_mode, skip_shares)
     runner.run_tasks(tasks_to_run, num_workers, is_dry_run, is_list_launches, execution_mode)
 
 

--- a/servicecatalog_puppet/core.py
+++ b/servicecatalog_puppet/core.py
@@ -103,6 +103,7 @@ def generate_tasks(f, single_account=None, is_dry_run=False, execution_mode='hub
             single_account=single_account,
             is_dry_run=is_dry_run,
             execution_mode=execution_mode,
+            skip_shares=skip_shares
         ),
     ]
 

--- a/servicecatalog_puppet/core.py
+++ b/servicecatalog_puppet/core.py
@@ -92,6 +92,7 @@ def generate_tasks(f, single_account=None, is_dry_run=False, execution_mode='hub
             single_account=single_account,
             is_dry_run=is_dry_run,
             execution_mode=execution_mode,
+            skip_shares=skip_shares
         ),
         spoke_local_portfolios_tasks.SpokeLocalPortfolioSectionTask(
             manifest_file_path=f.name,

--- a/servicecatalog_puppet/workflow/launch.py
+++ b/servicecatalog_puppet/workflow/launch.py
@@ -1,12 +1,6 @@
-import logging
-
 from servicecatalog_puppet.workflow import manifest as manifest_tasks
 from servicecatalog_puppet.workflow import provisioning as provisioning_tasks
 from servicecatalog_puppet.workflow import generate as generate_tasks
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
 
 class LaunchSectionTask(manifest_tasks.SectionTask):
     def params_for_results_display(self):
@@ -17,7 +11,6 @@ class LaunchSectionTask(manifest_tasks.SectionTask):
 
     def requires(self):
         if self.skip_shares:
-            logger.info(f"Skipping share setup..")
             return {
                 'manifest': manifest_tasks.ManifestTask(
                     manifest_file_path=self.manifest_file_path,

--- a/servicecatalog_puppet/workflow/launch.py
+++ b/servicecatalog_puppet/workflow/launch.py
@@ -11,22 +11,30 @@ class LaunchSectionTask(manifest_tasks.SectionTask):
         }
 
     def requires(self):
-        return {
-            'generate_shares': generate_tasks.GenerateSharesTask(
-                manifest_file_path=self.manifest_file_path,
-                puppet_account_id=self.puppet_account_id,
-                should_use_sns=self.should_use_sns,
-                should_use_product_plans=self.should_use_product_plans,
-                include_expanded_from=self.include_expanded_from,
-                single_account=self.single_account,
-                is_dry_run=self.is_dry_run,
-                execution_mode=self.execution_mode,
-            ),
-            'manifest': manifest_tasks.ManifestTask(
-                manifest_file_path=self.manifest_file_path,
-                puppet_account_id=self.puppet_account_id,
-            )
-        }
+        if self.skip_shares:
+            return {
+                'manifest': manifest_tasks.ManifestTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                )
+            }
+        else:
+            return {
+                'generate_shares': generate_tasks.GenerateSharesTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                    should_use_sns=self.should_use_sns,
+                    should_use_product_plans=self.should_use_product_plans,
+                    include_expanded_from=self.include_expanded_from,
+                    single_account=self.single_account,
+                    is_dry_run=self.is_dry_run,
+                    execution_mode=self.execution_mode,
+                ),
+                'manifest': manifest_tasks.ManifestTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                )
+            }
 
     def run(self):
         manifest = self.load_from_input('manifest')

--- a/servicecatalog_puppet/workflow/launch.py
+++ b/servicecatalog_puppet/workflow/launch.py
@@ -1,6 +1,11 @@
+import logging
+
 from servicecatalog_puppet.workflow import manifest as manifest_tasks
 from servicecatalog_puppet.workflow import provisioning as provisioning_tasks
 from servicecatalog_puppet.workflow import generate as generate_tasks
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
 class LaunchSectionTask(manifest_tasks.SectionTask):
@@ -12,6 +17,7 @@ class LaunchSectionTask(manifest_tasks.SectionTask):
 
     def requires(self):
         if self.skip_shares:
+            logger.info(f"Skipping share setup..")
             return {
                 'manifest': manifest_tasks.ManifestTask(
                     manifest_file_path=self.manifest_file_path,

--- a/servicecatalog_puppet/workflow/manifest.py
+++ b/servicecatalog_puppet/workflow/manifest.py
@@ -31,7 +31,7 @@ class SectionTask(tasks.PuppetTask):
     single_account = luigi.Parameter()
     is_dry_run = luigi.BoolParameter()
     execution_mode = luigi.Parameter()
-    skip_shares = luigi.Parameter()
+    skip_shares = luigi.BoolParameter()
 
     def params_for_results_display(self):
         return {

--- a/servicecatalog_puppet/workflow/manifest.py
+++ b/servicecatalog_puppet/workflow/manifest.py
@@ -31,7 +31,7 @@ class SectionTask(tasks.PuppetTask):
     single_account = luigi.Parameter()
     is_dry_run = luigi.BoolParameter()
     execution_mode = luigi.Parameter()
-    skip_shares = luigi.BoolParameter()
+    skip_shares = luigi.Parameter()
 
     def params_for_results_display(self):
         return {

--- a/servicecatalog_puppet/workflow/manifest.py
+++ b/servicecatalog_puppet/workflow/manifest.py
@@ -32,6 +32,7 @@ class SectionTask(tasks.PuppetTask):
     is_dry_run = luigi.BoolParameter()
     execution_mode = luigi.Parameter()
     skip_shares = luigi.BoolParameter()
+    generate_only = luigi.BoolParameter()
 
     def params_for_results_display(self):
         return {

--- a/servicecatalog_puppet/workflow/manifest.py
+++ b/servicecatalog_puppet/workflow/manifest.py
@@ -31,6 +31,7 @@ class SectionTask(tasks.PuppetTask):
     single_account = luigi.Parameter()
     is_dry_run = luigi.BoolParameter()
     execution_mode = luigi.Parameter()
+    skip_shares = luigi.BoolParameter()
 
     def params_for_results_display(self):
         return {

--- a/servicecatalog_puppet/workflow/provisioning.py
+++ b/servicecatalog_puppet/workflow/provisioning.py
@@ -936,8 +936,8 @@ class SpokeLocalPortfolioTask(ProvisioningTask):
 
     def generate_tasks(self, task_defs):
         if len(task_defs) == 0:
-            raise Exception(
-                f"The configuration for this share does not include any target accounts: {self.spoke_local_portfolio_name}")
+            logger.warning(f"The configuration for this share does not include any target accounts: {self.spoke_local_portfolio_name}")
+            return []
         first_task_def = task_defs[0]
         portfolio = first_task_def.get('portfolio')
         tasks = []

--- a/servicecatalog_puppet/workflow/spoke_local_portfolios.py
+++ b/servicecatalog_puppet/workflow/spoke_local_portfolios.py
@@ -1,5 +1,4 @@
 from servicecatalog_puppet.workflow import provisioning as provisioning_tasks
-
 from servicecatalog_puppet.workflow import manifest as manifest_tasks
 from servicecatalog_puppet.workflow import generate as generate_tasks
 
@@ -12,22 +11,30 @@ class SpokeLocalPortfolioSectionTask(manifest_tasks.SectionTask):
         }
 
     def requires(self):
-        return {
-            'generate_shares': generate_tasks.GenerateSharesTask(
-                manifest_file_path=self.manifest_file_path,
-                puppet_account_id=self.puppet_account_id,
-                should_use_sns=self.should_use_sns,
-                should_use_product_plans=self.should_use_product_plans,
-                include_expanded_from=self.include_expanded_from,
-                single_account=self.single_account,
-                is_dry_run=self.is_dry_run,
-                execution_mode=self.execution_mode,
-            ),
-            'manifest': manifest_tasks.ManifestTask(
-                manifest_file_path=self.manifest_file_path,
-                puppet_account_id=self.puppet_account_id,
-            )
-        }
+        if self.skip_shares:
+            return {
+                'manifest': manifest_tasks.ManifestTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                )
+            }
+        else:
+            return {
+                'generate_shares': generate_tasks.GenerateSharesTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                    should_use_sns=self.should_use_sns,
+                    should_use_product_plans=self.should_use_product_plans,
+                    include_expanded_from=self.include_expanded_from,
+                    single_account=self.single_account,
+                    is_dry_run=self.is_dry_run,
+                    execution_mode=self.execution_mode,
+                ),
+                'manifest': manifest_tasks.ManifestTask(
+                    manifest_file_path=self.manifest_file_path,
+                    puppet_account_id=self.puppet_account_id,
+                )
+            }
 
     def run(self):
         manifest = self.load_from_input('manifest')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds an optional command argument to the `deploy` command which will mean any GenerateShare tasks are skipped. This is useful for cases where setting up Portfolio / Policy shares are handled outside of Puppet.

This also adds a small change to when no tasks are present for a portfolio share. In previous versions this didn't fail the pipeline, but since `0.77.0` it does. This just reverts it back to the previous behaviour.

Finally it adds the `generate-shares` CLI command back for cases where users would just like to re-generate Portfolio / Product shares without running a full deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
