### PR TITLE
Adding missing parameter 'manifest_file_path' to PortfolioManagementT…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "aws-service-catalog-puppet"
-version = "0.80.1"
+version = "0.80.2"
 description = "Making it easier to deploy ServiceCatalog products"
 classifiers = ["Development Status :: 5 - Production/Stable", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent", "Natural Language :: English"]
 homepage = "https://service-catalog-tools-workshop.com/"

--- a/servicecatalog_puppet/workflow/portfoliomanagement.py
+++ b/servicecatalog_puppet/workflow/portfoliomanagement.py
@@ -1418,6 +1418,7 @@ class DisassociateProductsFromPortfolio(PortfolioManagementTask):
                     product_id=product_view_detail.get("ProductViewSummary").get(
                         "ProductId"
                     ),
+                    manifest_file_path=self.manifest_file_path,
                 )
             self.write_output(self.params_for_results_display())
 
@@ -1550,11 +1551,13 @@ class DeletePortfolio(PortfolioManagementTask):
                         account_id=self.account_id,
                         region=self.region,
                         portfolio_id=portfolio_id,
+                        manifest_file_path=self.manifest_file_path,
                     )
                     yield DeleteLocalPortfolio(
                         account_id=self.account_id,
                         region=self.region,
                         portfolio_id=portfolio_id,
+                        manifest_file_path=self.manifest_file_path,
                     )
 
             if not is_puppet_account:
@@ -1563,6 +1566,7 @@ class DeletePortfolio(PortfolioManagementTask):
                     region=self.region,
                     portfolio=self.portfolio,
                     puppet_account_id=self.puppet_account_id,
+                    manifest_file_path=self.manifest_file_path,
                 )
 
         # with betterboto_client.CrossAccountClientContextManager(


### PR DESCRIPTION
After recent changes, deleting portfolios no longer worked due to a missing parameter.

```luigi.parameter.MissingParameterException: DisassociateProductsFromPortfolio[args=(), kwargs={'account_id': '[REDACTED]', 'region': 'eu-west-1', 'portfolio_id': '[REDACTED]'}]: requires the 'manifest_file_path' parameter to be set```

This change fixes that.

*Issue #, if available:* NA

*Description of changes:*

Added the missing parameter and bumped the version number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
