### PR TITLE
Propagate LaunchTask execution_mode to ProvisionProductTask as default

### DIFF
--- a/servicecatalog_puppet/workflow/provisioning.py
+++ b/servicecatalog_puppet/workflow/provisioning.py
@@ -1090,7 +1090,9 @@ class LaunchTask(ProvisioningTask):
             task_def["is_dry_run"] = self.is_dry_run
 
             if task_status == constants.PROVISIONED:
-                provisioning_parameters = {}
+                provisioning_parameters = {
+                    'execution_mode': self.execution_mode
+                }
                 for p in ProvisionProductTask.get_param_names(include_significant=True):
                     provisioning_parameters[p] = task_def.get(p)
 


### PR DESCRIPTION
*Description of changes:*
Using version 0.80.2 (and since execution_mode was introduced), new ssm parameters added to outputs in launches configuration are not being added due to `execution_mode=None` in ProvisionProductTask

this property is present in LaunchTask (as "hub" in our usecase)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
