### PR TITLE
Fixing for loop for task generation in SpokeLocalPortfolioTask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "aws-service-catalog-puppet"
-version = "0.80.4"
+version = "0.80.5"
 description = "Making it easier to deploy ServiceCatalog products"
 classifiers = ["Development Status :: 5 - Production/Stable", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent", "Natural Language :: English"]
 homepage = "https://service-catalog-tools-workshop.com/"

--- a/servicecatalog_puppet/workflow/provisioning.py
+++ b/servicecatalog_puppet/workflow/provisioning.py
@@ -1272,50 +1272,50 @@ class SpokeLocalPortfolioTask(ProvisioningTask):
                 )
                 tasks.append(create_spoke_local_portfolio_task)
 
-        create_spoke_local_portfolio_task_as_dependency_params = {
-            "manifest_file_path": self.manifest_file_path,
-            "account_id": task_def.get("account_id"),
-            "region": task_def.get("region"),
-            "portfolio": portfolio,
-            "organization": task_def.get("organization"),
-        }
-
-        if len(task_def.get("associations", [])) > 0:
-            create_associations_for_portfolio_task = portfoliomanagement_tasks.CreateAssociationsForPortfolioTask(
-                **create_spoke_local_portfolio_task_as_dependency_params,
-                associations=task_def.get("associations"),
-                puppet_account_id=task_def.get("puppet_account_id"),
-                should_use_sns=task_def.get("should_use_sns"),
-            )
-            tasks.append(create_associations_for_portfolio_task)
-
-        launch_constraints = task_def.get("constraints", {}).get("launch", [])
-
-        if product_generation_method == "import":
-            import_into_spoke_local_portfolio_task = portfoliomanagement_tasks.ImportIntoSpokeLocalPortfolioTask(
-                **create_spoke_local_portfolio_task_as_dependency_params,
-                puppet_account_id=task_def.get("puppet_account_id"),
-            )
-            tasks.append(import_into_spoke_local_portfolio_task)
-        else:
-            copy_into_spoke_local_portfolio_task = portfoliomanagement_tasks.CopyIntoSpokeLocalPortfolioTask(
-                **create_spoke_local_portfolio_task_as_dependency_params,
-                puppet_account_id=task_def.get("puppet_account_id"),
-            )
-            tasks.append(copy_into_spoke_local_portfolio_task)
-
-        if len(launch_constraints) > 0:
-            create_launch_role_constraints_for_portfolio_task_params = {
-                "launch_constraints": launch_constraints,
-                "puppet_account_id": task_def.get("puppet_account_id"),
-                "should_use_sns": task_def.get("should_use_sns"),
+            create_spoke_local_portfolio_task_as_dependency_params = {
+                "manifest_file_path": self.manifest_file_path,
+                "account_id": task_def.get("account_id"),
+                "region": task_def.get("region"),
+                "portfolio": portfolio,
+                "organization": task_def.get("organization"),
             }
-            create_launch_role_constraints_for_portfolio = portfoliomanagement_tasks.CreateLaunchRoleConstraintsForPortfolio(
-                **create_spoke_local_portfolio_task_as_dependency_params,
-                **create_launch_role_constraints_for_portfolio_task_params,
-                product_generation_method=product_generation_method,
-            )
-            tasks.append(create_launch_role_constraints_for_portfolio)
+
+            if len(task_def.get("associations", [])) > 0:
+                create_associations_for_portfolio_task = portfoliomanagement_tasks.CreateAssociationsForPortfolioTask(
+                    **create_spoke_local_portfolio_task_as_dependency_params,
+                    associations=task_def.get("associations"),
+                    puppet_account_id=task_def.get("puppet_account_id"),
+                    should_use_sns=task_def.get("should_use_sns"),
+                )
+                tasks.append(create_associations_for_portfolio_task)
+
+            launch_constraints = task_def.get("constraints", {}).get("launch", [])
+
+            if product_generation_method == "import":
+                import_into_spoke_local_portfolio_task = portfoliomanagement_tasks.ImportIntoSpokeLocalPortfolioTask(
+                    **create_spoke_local_portfolio_task_as_dependency_params,
+                    puppet_account_id=task_def.get("puppet_account_id"),
+                )
+                tasks.append(import_into_spoke_local_portfolio_task)
+            else:
+                copy_into_spoke_local_portfolio_task = portfoliomanagement_tasks.CopyIntoSpokeLocalPortfolioTask(
+                    **create_spoke_local_portfolio_task_as_dependency_params,
+                    puppet_account_id=task_def.get("puppet_account_id"),
+                )
+                tasks.append(copy_into_spoke_local_portfolio_task)
+
+            if len(launch_constraints) > 0:
+                create_launch_role_constraints_for_portfolio_task_params = {
+                    "launch_constraints": launch_constraints,
+                    "puppet_account_id": task_def.get("puppet_account_id"),
+                    "should_use_sns": task_def.get("should_use_sns"),
+                }
+                create_launch_role_constraints_for_portfolio = portfoliomanagement_tasks.CreateLaunchRoleConstraintsForPortfolio(
+                    **create_spoke_local_portfolio_task_as_dependency_params,
+                    **create_launch_role_constraints_for_portfolio_task_params,
+                    product_generation_method=product_generation_method,
+                )
+                tasks.append(create_launch_role_constraints_for_portfolio)
         logger.info(f"tasks len are {len(tasks)}")
         logger.info(f"tasks are {tasks}")
         return tasks


### PR DESCRIPTION
Signed-off-by: Rob Reus <rob@devrobs.nl>

*Issue #, if available:*

*Description of changes:*

This bug got introduced in 34d5adf42583713877167ff9afc8c3c63d73b801 with the release of version 0.77.0. The code to create associations, import products etc... fell outside of the for loop, causing it to only be applied once on a random account which happend to be the last one in the for loop.

This fixes that issue by moving the code back into the for loop in which it was also before version 0.77.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
