### PR TITLE
Fix invalid Source Provider condition

### DIFF
--- a/servicecatalog_puppet/servicecatalog-puppet.template.yaml
+++ b/servicecatalog_puppet/servicecatalog-puppet.template.yaml
@@ -241,7 +241,7 @@ Resources:
               OutputArtifacts:
                 - Name: Source
               RunOrder: 1
-              {% if Source.Provider.lower() == 'aws' %}RoleArn: !GetAtt SourceRole.Arn{% endif %}
+              {% if Source.Provider.lower() == 'codecommit' %}RoleArn: !GetAtt SourceRole.Arn{% endif %}
         - Name: Deploy
           Actions:
             - !If


### PR DESCRIPTION
Replace "aws" with "codecommit" as AWS is not a valid source provider, and this logic prevents the role being added for CodeCommit users, in turn disabling automatic triggering on code push

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
