### PR TITLE
Accept portfolio share with PortfolioShareType for AWS_ORGANIZATIONS sharing mode

### DIFF
--- a/servicecatalog_puppet/workflow/portfoliomanagement.py
+++ b/servicecatalog_puppet/workflow/portfoliomanagement.py
@@ -1430,9 +1430,13 @@ class ShareAndAcceptPortfolioTask(
                     break
             if not was_accepted:
                 self.info(f"{self.uid}: accepting {self.portfolio_id}")
-                cross_account_servicecatalog.accept_portfolio_share(
-                    PortfolioId=self.portfolio_id,
-                )
+                portfolio_share_args = {
+                    'PortfolioId': self.portfolio_id
+                }
+                if self.sharing_mode == constants.SHARING_MODE_AWS_ORGANIZATIONS:
+                    portfolio_share_args['PortfolioShareType'] = 'AWS_ORGANIZATIONS'
+                
+                cross_account_servicecatalog.accept_portfolio_share(**portfolio_share_args)
 
             principals_for_portfolio = cross_account_servicecatalog.list_principals_for_portfolio_single_page(
                 PortfolioId=self.portfolio_id


### PR DESCRIPTION
*Issue #, if available:*
#346 

*Description of changes:*
Pass PortfolioShareType to servicecatalog.accept_portfolio_share to support AWS_ORGANIZATIONS shares

This could be done more neatly with the existing method, but I was trying to make it so that the method call is identical to before when people aren't using AWS_ORGANIZATIONS to (hopefully) avoid issues - it's probably a safe bet that the default 'PortfolioShareType' could be set to 'IMPORTED' though

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
