### PR TITLE
Force CustomResource in initializer template to execute every time 

### DIFF
--- a/servicecatalog_puppet/servicecatalog-puppet-initialiser.template.yaml
+++ b/servicecatalog_puppet/servicecatalog-puppet-initialiser.template.yaml
@@ -282,12 +282,28 @@ Resources:
               r = urlopen(req)
               logger.info("Status message: {} {}".format(r.msg, r.getcode()))
 
+  # Force custom resource to execute on every Stack update operation by passing in all parameters
   StartInstall:
     Type: Custom::CustomResource
     DependsOn: InitialiserProject
     Properties:
       ServiceToken: !GetAtt StartInstallLambda.Arn
       ProjectName: !Ref InitialiserProject
+      DummyVar1: !Ref EnabledRegions
+      DummyVar2: !Ref ShouldCollectCloudformationEvents
+      DummyVar3: !Ref ShouldForwardEventsToEventbridge
+      DummyVar4: !Ref ShouldForwardFailuresToOpscenter
+      DummyVar5: !Ref PuppetCodePipelineRolePermissionBoundary
+      DummyVar6: !Ref SourceRolePermissionsBoundary
+      DummyVar7: !Ref PuppetGenerateRolePermissionBoundary
+      DummyVar8: !Ref PuppetDeployRolePermissionBoundary
+      DummyVar9: !Ref PuppetProvisioningRolePermissionsBoundary
+      DummyVar10: !Ref CloudFormationDeployRolePermissionsBoundary
+      DummyVar11: !Ref PuppetRolePermissionBoundary
+      DummyVar12: !Ref DeployEnvironmentComputeType
+      DummyVar13: !Ref DeployNumWorkers
+      DummyVar14: !Ref PuppetRoleName
+      DummyVar15: !Ref PuppetRolePath
 
 Outputs:
   ServiceCatalogPuppetRepoConsoleURL:


### PR DESCRIPTION
*Issue description:*

We use a custom resource to execute a CodeBuild project which the initializer template has created.  Custom Resources are only called on Create/Update/Delete operations. As the only parameters for the custom resource are the ServiceToken & projectName, the custom resource is not called when changing parameters & updating the initializer stack.

The customer case here is updating the supported regions parameter to add new region(s).  The CodeBuild project is never executed and some core resources (SQS/SNS) never get created in the new regions - leading to errors when executing the puppet pipeline.

*Description of changes:*

I've passed in all CFN parameters as additional properties to the StartInstall custom resource.  These will never be used for anything, but ensure that any update operation on the CFN stack will trigger the custom resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
