### PR TITLE
Remove trust to spoke account. Trust puppet account only.

### DIFF
--- a/servicecatalog_puppet/servicecatalog-puppet-spoke.template.yaml
+++ b/servicecatalog_puppet/servicecatalog-puppet-spoke.template.yaml
@@ -99,11 +99,6 @@ Resources:
               AWS: !Sub "arn:${AWS::Partition}:iam::${PuppetAccountId}:root"
             Action:
               - "sts:AssumeRole"
-          - Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
-            Action:
-              - "sts:AssumeRole"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
*Description of changes:*

Remove trust to Spoke account. Only trust puppet account to assume the administrative role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
