### PR TITLE
Fixing wrong import, codebuild used to fail ModuleNotFoundError

### DIFF
--- a/servicecatalog_puppet/workflow/apps/app_for_task.py
+++ b/servicecatalog_puppet/workflow/apps/app_for_task.py
@@ -3,7 +3,7 @@
 
 import luigi
 
-import constants
+from servicecatalog_puppet import constants
 from servicecatalog_puppet.workflow.apps import app_base_task
 from servicecatalog_puppet.workflow.apps import provision_app_task
 from servicecatalog_puppet.workflow.manifest import manifest_mixin


### PR DESCRIPTION
Codebuild used to fail with error  
```plain
  File "/root/.pyenv/versions/3.7.**/lib/python3.7/site-packages/servicecatalog_puppet/workflow/apps/app_for_task.py", line 6, in <module>
    import constants
ModuleNotFoundError: No module named 'constants'
```

*Issue #407*
https://github.com/awslabs/aws-service-catalog-puppet/issues/407

*Description of changes:*
Wrong import in library, causing codebuild to fail during stack dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
