### PR TITLE
Add option to make OU Path expansion optional and ignore if not found

### DIFF
--- a/servicecatalog_puppet/manifest_utils.py
+++ b/servicecatalog_puppet/manifest_utils.py
@@ -559,7 +559,12 @@ def rewrite_scps(manifest, puppet_account_id):
 
 
 def expand_path(account, client):
-    ou = client.convert_path_to_ou(account.get("ou"))
+    try:
+        ou = client.convert_path_to_ou(account.get("ou"))
+    except Exception:
+        if account.get("optional", False):
+            return []
+        raise
     account["ou_name"] = account["ou"]
     account["ou"] = ou
     return expand_ou(account, client)


### PR DESCRIPTION
*Description of changes:*
Add an optional parameter in the accounts configuration (currently only implemented for OU paths, as I don't think it would be wanted for OU IDs)

This will allow OUs to be made optional, allowing simplification of configuration across multiple environments - currently we maintain 3 separate account lists for each of our environments (most of which is identical) because there is one OU that only exists in our development environment (but not test or production)

Adding an option to skip this OU if it doesn't exist (not done by default though) would be very useful to remove unnecessary duplication in our configuration

I'm not precious about the parameter name, happy to change it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
