### PR TITLE
check execution on item when determining GetSSMParam task to use

### DIFF
--- a/servicecatalog_puppet/workflow/general/get_ssm_param_task.py
+++ b/servicecatalog_puppet/workflow/general/get_ssm_param_task.py
@@ -59,7 +59,9 @@ class GetSSMParamByPathTask(tasks.PuppetTask):
             paginator = ssm.get_paginator("get_parameters_by_path")
             for page in paginator.paginate(Path=self.path, Recursive=self.recursive):
                 for parameter in page.get("Parameters", []):
-                    parameters[parameter.get("Name")] = dict(Value=parameter.get("Value"))
+                    parameters[parameter.get("Name")] = dict(
+                        Value=parameter.get("Value")
+                    )
 
         self.write_output(parameters)
 
@@ -217,8 +219,15 @@ class PuppetTaskWithParameters(tasks.PuppetTask):
                 parameter_is_in_hub = str(
                     param_details.get("ssm").get("account_id", "")
                 ) == str(self.puppet_account_id)
+                # Check the spoke parameter on the item - defaulting to true so the check is ignored if missing (to replicate existing functionality)
+                item_is_spoke = (
+                    constants.EXECUTION_MODE_SPOKE == self.execution
+                    if hasattr(self, "execution")
+                    else True
+                )
                 if (
                     constants.EXECUTION_MODE_SPOKE == self.execution_mode
+                    and item_is_spoke
                     and parameter_is_in_hub
                 ):
                     klass = GetSSMParamFromManifestTask


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Check the execution defined on the launch/stack etc. as well as the global execution_mode

I'm not sure if the hasattr check is required, however as this is defined in child classes I thought it would be safer, happy to remove though

Currently as execution_mode is checked, within the spoke CodeBuild job of the puppet account, hub products are being launched  and are failing to retrieve the SSM parameters as they have not been previously cached.

This worked previously when `self.execution = "hub" and parameter_is_in_hub = True`, as it will have gone into the standard `GetSSMParamTask`

However now that `self.execution_mode` is checked, when a hub product is processed, `self.execution_mode = "spoke" and parameter_is_in_hub = True`, so it'll drop into `GetSSMParamFromManifestTask`

I'm going to look through the logs to confirm whether the hub products were actually being launched before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
