### PR TITLE
reduce permissions available to PuppetDeployInSpokeRole

### DIFF
--- a/servicecatalog_puppet/servicecatalog-puppet-spoke.template.yaml
+++ b/servicecatalog_puppet/servicecatalog-puppet-spoke.template.yaml
@@ -123,8 +123,30 @@ Resources:
                 - "codebuild.amazonaws.com"
             Action:
               - "sts:AssumeRole"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
+      Policies:
+        - PolicyName: "CodeBuildSetup"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: sts:AssumeRole
+                Resource: !GetAtt PuppetRole.Arn
+              - Effect: "Allow"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+              - Effect: "Allow"
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:GetParametersByPath
+                  - ssm:ListParameters
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:DeleteParameters
+                Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*"
 
   DeployInSpokeProject:
     Type: AWS::CodeBuild::Project


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reduce the scope of permissions available to `servicecatalog-puppet/PuppetDeployInSpokeRole` from AdministratorAccess as most actions are performed by PuppetRole instead, so this level access doesn't seem to be needed

This _could_ be a privilege escalation risk currently if someone else used the role for a codebuild job.

I retrieved the high-level services being used via access advisor on the existing role and a single account run works as expected

I'm not 100% sure what SSM parameters would be read/modified though - might just be old data from access advisor as I think it's been over a month since the service was accessed

We're currently running a slightly older 0.129.0 but looking to upgrade, wanted to get this PR out for review initially though before I test on latest though

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
