### PR TITLE
Add variable PARTITION to build projects.

### DIFF
--- a/servicecatalog_puppet/servicecatalog-puppet.template.yaml
+++ b/servicecatalog_puppet/servicecatalog-puppet.template.yaml
@@ -522,6 +522,9 @@ Resources:
           - Name: ASSUMABLE_ROLE_IN_ROOT_ACCOUNT
             Type: PLAINTEXT
             Value: CHANGE_ME
+          - Name: PARTITION
+            Type: PARAMETER_STORE
+            Value: !Ref PartitionParameter
       Source:
         Type: NO_SOURCE
         BuildSpec: |
@@ -563,6 +566,9 @@ Resources:
           - Name: IAM_ROLE_ARNS
             Type: PLAINTEXT
             Value: ''
+          - Name: PARTITION
+            Type: PARAMETER_STORE
+            Value: !Ref PartitionParameter
       Source:
         Type: NO_SOURCE
         BuildSpec: |


### PR DESCRIPTION
FIx https://github.com/awslabs/aws-service-catalog-puppet/issues/540

Some builder projects lacks of "PARTITION" environment variables, which leads to failed builds in AWS China region since it's default to `aws`.

