### PR TITLE
fix: single account run fix for when ssm output is in a launch or whe…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -230,16 +230,6 @@ files = [
 ]
 
 [[package]]
-name = "colorclass"
-version = "2.2.0"
-description = "Colorful worry-free console applications for Linux, Mac OS X, and Windows."
-optional = false
-python-versions = "*"
-files = [
-    {file = "colorclass-2.2.0.tar.gz", hash = "sha256:b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b"},
-]
-
-[[package]]
 name = "coverage"
 version = "6.5.0"
 description = "Code coverage measurement for Python"
@@ -1328,4 +1318,4 @@ pyyaml = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3e240fadffcaa3cc40bc982a2c69ef841eb1ae7b07eb48b95aaa0a83de102d21"
+content-hash = "57c4d66684b2dc11a9647877c8acce0113d9e1f0dbe9048e4982693fdc7f583b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "aws-service-catalog-puppet"
-version = "0.241.0"
+version = "0.242.0"
 description = "Making it easier to deploy ServiceCatalog products"
 classifiers = ["Development Status :: 5 - Production/Stable", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent", "Natural Language :: English"]
 homepage = "https://service-catalog-tools-workshop.com/"
@@ -49,7 +49,6 @@ click = "==7.0"
 boto3 = "1.26.15"
 better-boto = "0.42.0"
 terminaltables = "==3.1.0"
-colorclass = "==2.2.0"
 luigi = "3.1.1"
 cfn-flip = "==1.2.3"
 networkx = "2.6.3"

--- a/servicecatalog_puppet/commands/task_reference.py
+++ b/servicecatalog_puppet/commands/task_reference.py
@@ -100,6 +100,9 @@ def deploy_from_task_reference(path):
                         str(single_account_id),
                         str(puppet_account_id),
                     ]:
+                        print(
+                            f"Going to continue on {task_reference} {task_section_name} {str(task_account_id)}"
+                        )
                         continue
 
                 tasks_to_run_filtered[task_reference] = task

--- a/servicecatalog_puppet/commands/task_reference.py
+++ b/servicecatalog_puppet/commands/task_reference.py
@@ -100,9 +100,6 @@ def deploy_from_task_reference(path):
                         str(single_account_id),
                         str(puppet_account_id),
                     ]:
-                        print(
-                            f"Going to continue on {task_reference} {task_section_name} {str(task_account_id)}"
-                        )
                         continue
 
                 tasks_to_run_filtered[task_reference] = task

--- a/servicecatalog_puppet/commands/task_reference_helpers/generators/launches.py
+++ b/servicecatalog_puppet/commands/task_reference_helpers/generators/launches.py
@@ -217,19 +217,18 @@ def handle_launches(
         task_reference_constants.MANIFEST_ACCOUNT_IDS
     ].update(task_to_add.get(task_reference_constants.MANIFEST_ACCOUNT_IDS))
 
-    # GET all the products for the spoke
-    if spoke_portfolio_puppet_association_ref is None:
-        deps = [portfolio_deploying_from]
-    else:
-        deps = [portfolio_deploying_from, spoke_portfolio_puppet_association_ref]
-    portfolio_get_all_products_and_their_versions_ref = f"{constants.PORTFOLIO_GET_ALL_PRODUCTS_AND_THEIR_VERSIONS}-{task_to_add.get('account_id')}-{section_name}-{item_name}--{task_to_add.get('region')}-{task_to_add.get('portfolio')}"
+    # GET all the products from the hub for the spoke
+    portfolio_get_all_products_and_their_versions_ref = f"{constants.PORTFOLIO_GET_ALL_PRODUCTS_AND_THEIR_VERSIONS}-{puppet_account_id}-{task_to_add.get('region')}-{task_to_add.get('portfolio')}"
     if not all_tasks.get(portfolio_get_all_products_and_their_versions_ref):
         all_tasks[portfolio_get_all_products_and_their_versions_ref] = {
             "execution": task_to_add.get("execution"),
             "puppet_account_id": puppet_account_id,
             "task_reference": portfolio_get_all_products_and_their_versions_ref,
-            "dependencies_by_reference": deps,
-            "portfolio_task_reference": portfolio_deploying_from,
+            "dependencies_by_reference": [
+                hub_portfolio_ref,
+                hub_portfolio_puppet_association_ref,
+            ],
+            "portfolio_task_reference": hub_portfolio_ref,
             "account_id": puppet_account_id,
             "region": task_to_add.get("region"),
             "section_name": constants.PORTFOLIO_GET_ALL_PRODUCTS_AND_THEIR_VERSIONS,

--- a/servicecatalog_puppet/commands/task_reference_helpers/generators/ssm_outputs_handler.py
+++ b/servicecatalog_puppet/commands/task_reference_helpers/generators/ssm_outputs_handler.py
@@ -54,7 +54,28 @@ def ssm_outputs_handler(
             "status": task_to_add.get("status"),
             "section_name": constants.SSM_OUTPUTS,
             "execution": task_to_add.get("execution", constants.EXECUTION_MODE_DEFAULT),
+            "task_generating_output_account_id": task_to_add.get("account_id"),
+            "task_generating_output_region": task_to_add.get("region"),
+            "task_generating_output_section_name": task_to_add.get("section_name"),
         }
+        if task_to_add.get("section_name") == constants.LAUNCHES:
+            task_generating_output_entity_name = task_to_add.get("launch_name")
+        elif task_to_add.get("section_name") == constants.STACKS:
+            task_generating_output_entity_name = task_to_add.get("stack_name")
+            all_tasks[ssm_parameter_output_task_reference][
+                "task_generating_output_stack_set_name"
+            ] = task_to_add.get("stack_set_name")
+            all_tasks[ssm_parameter_output_task_reference][
+                "task_generating_output_launch_name"
+            ] = task_to_add.get("launch_name")
+
+        else:
+            raise Exception(f"Unknown section name: {task_to_add.get('section_name')}")
+
+        all_tasks[ssm_parameter_output_task_reference][
+            "task_generating_output_entity_name"
+        ] = task_generating_output_entity_name
+
         all_tasks[ssm_parameter_output_task_reference][
             task_reference_constants.MANIFEST_SECTION_NAMES
         ][section_name] = True

--- a/servicecatalog_puppet/workflow/dependencies/task_factory.py
+++ b/servicecatalog_puppet/workflow/dependencies/task_factory.py
@@ -172,6 +172,24 @@ def create(
                 param_name=parameters_to_use.get("param_name"),
                 stack_output=parameters_to_use.get("stack_output"),
                 task_generating_output=parameters_to_use.get("task_generating_output"),
+                task_generating_output_account_id=parameters_to_use.get(
+                    "task_generating_output_account_id"
+                ),
+                task_generating_output_region=parameters_to_use.get(
+                    "task_generating_output_region"
+                ),
+                task_generating_output_section_name=parameters_to_use.get(
+                    "task_generating_output_section_name"
+                ),
+                task_generating_output_entity_name=parameters_to_use.get(
+                    "task_generating_output_entity_name"
+                ),
+                task_generating_output_stack_set_name=parameters_to_use.get(
+                    "task_generating_output_stack_set_name"
+                ),
+                task_generating_output_launch_name=parameters_to_use.get(
+                    "task_generating_output_launch_name"
+                ),
                 force_operation=parameters_to_use.get("force_operation"),
             )
     elif section_name == constants.TAG_POLICIES:

--- a/servicecatalog_puppet/workflow/runner.py
+++ b/servicecatalog_puppet/workflow/runner.py
@@ -13,12 +13,10 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 import click
-import colorclass
 import luigi
 import terminaltables
 import yaml
 from betterboto import client as betterboto_client
-from colorclass import Color
 from luigi import LuigiStatusCode
 
 from servicecatalog_puppet import (
@@ -214,23 +212,9 @@ def run_tasks(
 
             for filename in dry_run_tasks:
                 result = serialisation_utils.json_loads(open(filename, "r").read())
-                current_version = (
-                    Color("{green}" + result.get("current_version") + "{/green}")
-                    if result.get("current_version") == result.get("new_version")
-                    else Color("{red}" + result.get("current_version") + "{/red}")
-                )
-
-                active = (
-                    Color("{green}" + str(result.get("active")) + "{/green}")
-                    if result.get("active")
-                    else Color("{red}" + str(result.get("active")) + "{/red}")
-                )
-
-                current_status = (
-                    Color("{green}" + result.get("current_status") + "{/green}")
-                    if result.get("current_status") == "AVAILABLE"
-                    else Color("{red}" + result.get("current_status") + "{/red}")
-                )
+                current_version = result.get("current_version")
+                active = str(result.get("active"))
+                current_status = result.get("current_status")
 
                 table.append(
                     [
@@ -386,11 +370,7 @@ def run_tasks(
                             f"OpsItem: {title} creation failed due to OpsItemLimitExceededException. OperationalData: {operational_data}"
                         )
                 if "RunDeployInSpoke" in filename:
-                    click.echo(
-                        colorclass.Color(
-                            "{red}" + result.get("task_type") + " failed{/red}"
-                        )
-                    )
+                    click.echo(result.get("task_type") + " failed")
                     click.echo(
                         f"{yaml.safe_dump({'parameters': result.get('task_params')})}"
                     )
@@ -493,9 +473,7 @@ def run_tasks_for_bootstrap_spokes_in_ou(tasks_to_run, num_workers):
 
     for filename in glob("results/failure/*.json"):
         result = serialisation_utils.json_loads(open(filename, "r").read())
-        click.echo(
-            colorclass.Color("{red}" + result.get("task_type") + " failed{/red}")
-        )
+        click.echo(result.get("task_type") + " failed")
         click.echo(f"{yaml.safe_dump({'parameters': result.get('task_params')})}")
         click.echo("\n".join(result.get("exception_stack_trace")))
         click.echo("")

--- a/servicecatalog_puppet/workflow/ssm/ssm_outputs_task_test.py
+++ b/servicecatalog_puppet/workflow/ssm/ssm_outputs_task_test.py
@@ -12,6 +12,12 @@ class SSMOutputsTasksTest(tasks_unit_tests_helper.PuppetTaskUnitTest):
     param_name = "param_name"
     stack_output = "stack_output"
     task_generating_output = "task_generating_output"
+    task_generating_output_account_id = "task_generating_output_account_id"
+    task_generating_output_region = "task_generating_output_region"
+    task_generating_output_section_name = "task_generating_output_section_name"
+    task_generating_output_entity_name = "task_generating_output_entity_name"
+    task_generating_output_stack_set_name = "task_generating_output_stack_set_name"
+    task_generating_output_launch_name = "task_generating_output_launch_name"
     force_operation = False
 
     def setUp(self) -> None:
@@ -25,7 +31,13 @@ class SSMOutputsTasksTest(tasks_unit_tests_helper.PuppetTaskUnitTest):
             region=self.region,
             param_name=self.param_name,
             stack_output=self.stack_output,
-            task_generating_output=self.task_generating_output
+            task_generating_output=self.task_generating_output,
+            task_generating_output_account_id=self.task_generating_output_account_id,
+            task_generating_output_region=self.task_generating_output_region,
+            task_generating_output_section_name=self.task_generating_output_section_name,
+            task_generating_output_entity_name=self.task_generating_output_entity_name,
+            task_generating_output_stack_set_name=self.task_generating_output_stack_set_name,
+            task_generating_output_launch_name=self.task_generating_output_launch_name,
         )
 
         self.wire_up_mocks()
@@ -72,7 +84,7 @@ class TerminateSSMOutputsTasksTest(tasks_unit_tests_helper.PuppetTaskUnitTest):
             **self.get_common_args(),
             account_id=self.account_id,
             region=self.region,
-            param_name=self.param_name
+            param_name=self.param_name,
         )
 
         self.wire_up_mocks()

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ install_requires = \
  'cfn-flip==1.2.3',
  'click==7.0',
  'colorama>=0.4.5,<0.5.0',
- 'colorclass==2.2.0',
  'deepdiff>=5.3.0,<6.0.0',
  'deepmerge>=0.2.1,<0.3.0',
  'jinja2==2.11.3',
@@ -74,7 +73,7 @@ entry_points = \
 
 setup_kwargs = {
     'name': 'aws-service-catalog-puppet',
-    'version': '0.241.0',
+    'version': '0.242.0',
     'description': 'Making it easier to deploy ServiceCatalog products',
     'long_description': '# aws-service-catalog-puppet\n\n![logo](./docs/logo.png) \n\n## Badges\n\n[![codecov](https://codecov.io/gh/awslabs/aws-service-catalog-puppet/branch/master/graph/badge.svg?token=e8M7mdsmy0)](https://codecov.io/gh/awslabs/aws-service-catalog-puppet)\n\n\n## What is it?\nThis is a python3 framework that makes it easier to share multi region AWS Service Catalog portfolios and makes it \npossible to provision products into accounts declaratively using a metadata based rules engine.\n\nWith this framework you define your accounts in a YAML file.  You give each account a set of tags, a default region and \na set of enabled regions.\n\nOnce you have done this you can define portfolios should be shared with each set of accounts using the tags and you \ncan specify which regions the shares occur in.\n\nIn addition to this, you can also define products that should be provisioned into accounts using the same tag based \napproach.  The framework will assume role into the target account and provision the product on your behalf.\n\n\n## Getting started\n\nYou can read the [installation how to](https://service-catalog-tools-workshop.com/30-how-tos/10-installation/30-service-catalog-puppet.html)\nor you can read through the [every day use](https://service-catalog-tools-workshop.com/30-how-tos/50-every-day-use.html)\nguides.\n\nYou can read the [documentation](https://aws-service-catalog-puppet.readthedocs.io/en/latest/) to understand the inner \nworkings. \n\n\n## Going further\n\nThe framework is one of a pair.  The other is [aws-service-catalog-factory](https://github.com/awslabs/aws-service-catalog-factory).\nWith Service Catalog Factory you can create pipelines that deploy multi region portfolios very easily. \n\n## License\n\nThis library is licensed under the Apache 2.0 License. \n \n',
     'author': 'Eamonn Faherty',


### PR DESCRIPTION
…n ssm output is in a stack and caching is disabled. Removing dependency for color library. fixed issue with launches where too many get all version task being created

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
